### PR TITLE
Fix edge case where valid 24 bit audio files fail to parse

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wave-chunk-parser"
-version = "1.5.0"
+version = "1.5.1"
 description = ""
 authors = ["Marc Steele <steelegbr@gmail.com>"]
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.md", "r", encoding="UTF-8") as fh:
 
 setuptools.setup(
     name="wave-chunk-parser",
-    version="1.5.0",
+    version="1.5.1",
     author="Marc Steele",
     author_email="steelegbr@gmail.com",
     description="Parses and writes WAVE file chunks",

--- a/wave_chunk_parser/chunks.py
+++ b/wave_chunk_parser/chunks.py
@@ -399,7 +399,7 @@ class DataChunk(Chunk):
             # use raw data of 3 bytes as sample for 24 bits
             # [disadvantage: the samples must be converted by caller before processing]
             samples = np.frombuffer(
-                raw,
+                raw[0:(len(raw) - (len(raw) % 3))],
                 dtype=np.dtype("V3"),
             )
         else:

--- a/wave_chunk_parser/chunks.py
+++ b/wave_chunk_parser/chunks.py
@@ -399,7 +399,7 @@ class DataChunk(Chunk):
             # use raw data of 3 bytes as sample for 24 bits
             # [disadvantage: the samples must be converted by caller before processing]
             samples = np.frombuffer(
-                raw[0:(len(raw) - (len(raw) % 3))],
+                raw[0 : (len(raw) - (len(raw) % 3))],
                 dtype=np.dtype("V3"),
             )
         else:


### PR DESCRIPTION
## What?
Certain valid 24-bit wave files (loaded in audacity without issue) failed to be parsed (M1 MacOS 14.6, Python 3.11, wave-chunk-parser 1.5.0). This change addresses these edge case 24-bit wave files.
## Why?
This allows valid 24-bit wave files which were previously failing to now successfully parse.
## How?
Sliced out remainder bytes from 24-bit branch of from_file_with_format method.
## Testing?
Ran existing unit tests (passed, no change required). Also validated against the attached sample file.
## Sample File
[ss.wav.zip](https://github.com/user-attachments/files/16737638/ss.wav.zip)

